### PR TITLE
Add a nix-based test-infrastructure

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+use flake || use nix
+watch_file flake.nix
+
+PATH_add ./scripts

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ migrate_working_dir/
 *.iws
 .idea/
 
+# Nix related
+/.direnv
+/result
+/result-*
+
 # The .vscode folder contains launch configuration and tasks you configure in
 # VS Code which you may wish to be included in version control, so this line
 # is commented out by default.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ----
 
-Task menagement application with in-built git integration.
+Task management application with in-built git integration.
 
 > [!WARNING]
 > This is currently alpha, so **everything** is subject to change.

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -37,7 +37,7 @@ const APPLICATION_NAME: &str = "stride";
 
 /// Choose correct path prefix based on availability.
 ///
-/// Currently it seems that dart's `path_provider` package does not seem to be consitent
+/// Currently it seems that dart's `path_provider` package does not seem to be consistent
 /// when creating the paths. Sometimes the path is the application id and other times it's
 /// the application name.
 fn choose_path_suffix(path: &Path) -> PathBuf {
@@ -203,7 +203,7 @@ fn main() -> anyhow::Result<()> {
                         break 'outer;
                     }
 
-                    // TODO: Make history formating configurable.
+                    // TODO: Make history formatting configurable.
                     println!(
                         "{:4}. {} {} {} {}",
                         count + 1,

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,120 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1728182355,
+        "narHash": "sha256-RyQMxBhpaZfL0AqEyuiM8I7aAtxDVc9siAsNMY8WFTs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7d49afd36b5590f023ec56809c02e05d8164fbc4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1728181869,
+        "narHash": "sha256-sQXHXsjIcGEoIHkB+RO6BZdrPfB+43V1TEpyoWRI3ww=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "cd46aa3906c14790ef5cbe278d9e54f2c38f95c0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1727984844,
+        "narHash": "sha256-xpRqITAoD8rHlXQafYZOLvUXCF6cnZkPfoq67ThN0Hc=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "4446c7a6fc0775df028c5a3f6727945ba8400e64",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -59,16 +59,25 @@
         else pkgs.rust-bin.stable.latest.default;
 
       treefmtEval = import ./treefmt.nix {inherit treefmt-nix pkgs;};
+
+      cli = pkgs.callPackage ./packages/cli.nix {};
+
       tests = import ./tests.nix {
         inherit pkgs;
         inherit (pkgs) lib;
         specialArgs = {
+          stride-cli = cli;
           nixos-lib = import (nixpkgs + "/nixos/lib") {};
         };
       };
     in {
+      packages = {
+        inherit cli;
+      };
+
       checks =
         {
+          inherit cli;
           formatting = treefmtEval.config.build.check self;
         }
         // tests;

--- a/flake.nix
+++ b/flake.nix
@@ -59,10 +59,19 @@
         else pkgs.rust-bin.stable.latest.default;
 
       treefmtEval = import ./treefmt.nix {inherit treefmt-nix pkgs;};
-    in {
-      checks = {
-        formatting = treefmtEval.config.build.check self;
+      tests = import ./tests.nix {
+        inherit pkgs;
+        inherit (pkgs) lib;
+        specialArgs = {
+          nixos-lib = import (nixpkgs + "/nixos/lib") {};
+        };
       };
+    in {
+      checks =
+        {
+          formatting = treefmtEval.config.build.check self;
+        }
+        // tests;
 
       formatter = treefmtEval.config.build.wrapper;
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,94 @@
+{
+  description = "Task management tool that synchronizes with git.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+      };
+    };
+
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+      };
+    };
+
+    # inputs for following
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+    flake-utils = {
+      url = "github:numtide/flake-utils";
+      inputs = {};
+    };
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    treefmt-nix,
+    rust-overlay,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [(import rust-overlay)];
+      };
+      unfreePkgs = import nixpkgs {
+        inherit system;
+        overlays = [(import rust-overlay)];
+        config.allowUnfree = true;
+        config.android_sdk.accept_license = true;
+      };
+      android = unfreePkgs.androidenv.composeAndroidPackages {
+        cmdLineToolsVersion = "11.0";
+      };
+
+      nightly = false;
+      rust =
+        if nightly
+        then pkgs.rust-bin.selectLatestNightlyWith (toolchain: toolchain.default)
+        else pkgs.rust-bin.stable.latest.default;
+
+      treefmtEval = import ./treefmt.nix {inherit treefmt-nix pkgs;};
+    in {
+      checks = {
+        formatting = treefmtEval.config.build.check self;
+      };
+
+      formatter = treefmtEval.config.build.wrapper;
+
+      devShells.default = pkgs.mkShell {
+        nativeBuildInputs = [
+          # Required for building the `openssl-sys` crate, as this uses `perl` to configure
+          # `openssl`.
+          pkgs.perl
+        ];
+
+        env = {
+          ANDROID_HOME = "${android.androidsdk}/libexec/android-sdk";
+          JAVA_HOME = pkgs.jdk17;
+          ANDROID_AVD_HOME = (builtins.toString ./.) + "/.android/avd";
+        };
+
+        packages = [
+          rust
+          pkgs.cargo-edit
+
+          pkgs.flutter
+          pkgs.jdk17
+          android.platform-tools
+        ];
+      };
+    });
+}
+# vim: ts=2
+

--- a/packages/cli.nix
+++ b/packages/cli.nix
@@ -1,0 +1,58 @@
+{
+  rustPlatform,
+  lib,
+  # nativeBuildInputs
+  perl,
+  ...
+}: let
+  pname = "stride";
+in
+  rustPlatform.buildRustPackage {
+    version = "0.1.0";
+    inherit pname;
+
+    # Nix needs to rebuild a package every time its source changes.
+    # Thus we filter out all the files in this repository that are not relevant for the
+    # `stride` cli, to avoid having to rebuild it, when a irrelevant file has been
+    # changed.
+    src = lib.cleanSourceWith {
+      # Apply the default source cleaning from nixpkgs
+      src = lib.cleanSource ./..;
+
+      # This has been taken from `crane` at:
+      # https://github.com/ipetkov/crane/blob/fd86b78f5f35f712c72147427b1eb81a9bd55d0b/lib/filterCargoSources.nix
+      filter = orig_path: type: let
+        path = builtins.toString orig_path;
+        base = builtins.baseNameOf path;
+        parentDir = builtins.baseNameOf (builtins.dirOf path);
+
+        matchesSuffix = lib.any (suffix: lib.hasSuffix suffix base) [
+          # Keep rust sources
+          ".rs"
+          # Keep all toml files as they are commonly used to configure other
+          # cargo-based tools
+          ".toml"
+        ];
+
+        # Cargo.toml already captured above
+        isCargoFile = base == "Cargo.lock";
+
+        # .cargo/config.toml already captured above
+        isCargoConfig = parentDir == ".cargo" && base == "config";
+      in
+        type == "directory" || matchesSuffix || isCargoFile || isCargoConfig;
+
+      name = pname;
+    };
+
+    nativeBuildInputs = [
+      # Required by the `openssl` crate
+      perl
+    ];
+
+    doCheck = true;
+
+    cargoLock = {
+      lockFile = ../Cargo.lock;
+    };
+  }

--- a/tests.nix
+++ b/tests.nix
@@ -1,0 +1,26 @@
+{
+  pkgs,
+  lib,
+  specialArgs,
+}: let
+  # for `nix eval --file` (as it does not support args) use:
+  # ```
+  # specialArgs = {};
+  # pkgs = (builtins.getFlake "nixpkgs").legacyPackages."x86_64-linux";
+  # inherit (pkgs) lib;
+  # ```
+  # instead of the function arguments above.
+  importTests' = test: let
+    basename = builtins.baseNameOf test;
+    testName = builtins.baseNameOf (lib.strings.removeSuffix "/${basename}" "${builtins.toString test}");
+  in {
+    name = "${testName}";
+    value = pkgs.callPackage test specialArgs;
+  };
+
+  importTests = dir:
+    builtins.listToAttrs (builtins.map importTests' (
+      lib.fileset.toList (lib.fileset.fileFilter (file: file.name == "test.nix") dir)
+    ));
+in
+  importTests ./tests

--- a/tests/git-sync/ssh_keys.nix
+++ b/tests/git-sync/ssh_keys.nix
@@ -1,0 +1,18 @@
+{pkgs}: {
+  admin = rec {
+    priv = pkgs.writeText "id_ed25519" ''
+      -----BEGIN OPENSSH PRIVATE KEY-----
+      b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+      QyNTUxOQAAACDu7qxYQAPdAU6RrhB3llk2N1v4PTwcVzcX1oX265uC3gAAAJBJiYxDSYmM
+      QwAAAAtzc2gtZWQyNTUxOQAAACDu7qxYQAPdAU6RrhB3llk2N1v4PTwcVzcX1oX265uC3g
+      AAAEDE1W6vMwSEUcF1r7Hyypm/+sCOoDmKZgPxi3WOa1mD2u7urFhAA90BTpGuEHeWWTY3
+      W/g9PBxXNxfWhfbrm4LeAAAACGJmb0BtaW5pAQIDBAU=
+      -----END OPENSSH PRIVATE KEY-----
+    '';
+
+    pub = ''
+      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO7urFhAA90BTpGuEHeWWTY3W/g9PBxXNxfWhfbrm4Le root@client
+    '';
+    pubFile = pkgs.writeText "id_ed25519.pub" pub;
+  };
+}

--- a/tests/git-sync/test.nix
+++ b/tests/git-sync/test.nix
@@ -1,0 +1,174 @@
+{
+  pkgs,
+  nixos-lib,
+  stride-cli,
+  ...
+}: let
+  sshKeys =
+    import ./ssh_keys.nix {inherit pkgs;};
+in
+  nixos-lib.runTest {
+    hostPkgs = pkgs;
+    name = "git-sync";
+
+    nodes = let
+      clientConfig = {...}: {
+        environment.systemPackages = [
+          stride-cli
+          pkgs.git
+          pkgs.python312
+        ];
+      };
+    in {
+      server = {...}: {
+        environment.systemPackages = [
+          pkgs.git
+        ];
+        users = {
+          users.git = {
+            isNormalUser = true;
+            openssh.authorizedKeys.keys = [
+              sshKeys.admin.pub
+            ];
+
+            group = "git";
+          };
+          groups.git = {};
+        };
+
+        services.openssh = {
+          enable = true;
+          ports = [22];
+          settings = {
+            PasswordAuthentication = false;
+            UseDns = true;
+            X11Forwarding = false;
+            PermitRootLogin = "prohibit-password";
+            # Allow all MACs (otherwise `stride` fails to find a matching MAC to use when
+            # communicating the sshd)
+            Macs = null;
+          };
+        };
+      };
+
+      client_send = clientConfig;
+      client_receive = clientConfig;
+    };
+    testScript = {nodes, ...}: let
+      cfg = nodes.server;
+      port = builtins.toString (builtins.elemAt cfg.services.openssh.ports 0);
+
+      user-dirs-file = pkgs.writeText "user-dirs.dirs" ''
+        XDG_DOCUMENTS_DIR="/root/Documents"
+      '';
+
+      strideTasksRepoPath = "/srv/git/stride-tasks.git";
+
+      sshKeyUuid = "93d873d5-96c8-47df-80a4-d5edec397828";
+      adjustConfig = pkgs.writeText "adjust_config.py" ''
+        import json
+        import sys
+
+        with sys.stdin as f:
+            d = json.load(f)
+            d["repository"]["ssh_key_uuid"] = "${sshKeyUuid}"
+            d["repository"]["origin"] = "git@server:${strideTasksRepoPath}"
+            d["repository"]["encryption"]["key"] = "lfRpC9kVZmG3iw4Vaq1fTB5DETvmSndM3jLR6WAdnkM"
+            print(json.dumps(d, sort_keys=True, indent=2))
+      '';
+      settingsPath = "/root/.local/share/org.stridetasks.stride";
+      settingsJsonPath = "${settingsPath}/settings.json";
+      settingsSshKeyPath = "${settingsPath}/.ssh/keys/${sshKeyUuid}";
+    in
+      /*
+      python
+      */
+      ''
+        start_all()
+
+        with subtest("Setup ssh keys on clients"):
+          for client in [client_send, client_receive]:
+              client.succeed(
+                  "mkdir -p ~root/.ssh",
+                  "cp ${sshKeys.admin.priv} ~root/.ssh/id_ed25519",
+                  "chmod 600 ~root/.ssh/id_ed25519",
+              )
+
+        with subtest("git server starts"):
+          server.wait_for_unit("sshd.service")
+          server.wait_for_open_port(${port})
+
+        with subtest("Create server git repository"):
+          server.succeed("${pkgs.writeShellScript "setup-git-repo" ''
+          set -xe
+
+          mkdir --parents ${strideTasksRepoPath}
+          chown --recursive git:git ${strideTasksRepoPath}
+          cd ${strideTasksRepoPath}
+
+          # We set the `initial-branch` here, so that cloning this repository will result in
+          # git checking out the `main` branch directly (which is what `stride` pushes),
+          # instead of trying to checkout the default `master` (which will not exist).
+          sudo --user=git git init --bare --initial-branch=main
+        ''}")
+
+        with subtest("Setup task syncing"):
+          for client in [client_send, client_receive]:
+              # The `TaskStorage` needs a document dir, which `stride` reads from the
+              # `user-dirs.dirs` file (via the `dirs` crate)
+              client.succeed(
+                  "mkdir ~/.config",
+                  "cat ${user-dirs-file} > ~/.config/user-dirs.dirs",
+                  "mkdir ~/Documents"
+              )
+
+              # Create all the metadata files (with the exception of the repository)
+              client.succeed('stride ""')
+
+              # This adds the required key attributes and such.
+              client.succeed(
+                  'echo "$(cat ${settingsJsonPath} | python3 ${adjustConfig})" > ${settingsJsonPath}'
+              )
+              # Add the ssh key
+              client.succeed(
+                "install -D ${sshKeys.admin.pubFile} ${settingsSshKeyPath}/key.pub",
+                "install -D ${sshKeys.admin.priv} ${settingsSshKeyPath}/key",
+              )
+              # Add the hostKey
+              client.succeed("ssh-keyscan -p ${port} -q server  > ${settingsPath}/.ssh/known_hosts")
+              client.succeed("ssh-keyscan -p ${port} -q server  > ~root/.ssh/known_hosts")
+
+          # Add the required git remote setup
+          client_send.succeed("${pkgs.writeShellScript "git-remote-setup" ''
+          set -xe
+
+          # This also creates the `repository` directory, needed below
+          stride add "Task 1 of client_send"
+
+          cd ${settingsPath}/repository
+          git remote add origin git@server:${strideTasksRepoPath}
+          git push --set-upstream origin main
+        ''}")
+          client_receive.succeed("${pkgs.writeShellScript "git-remote-setup" ''
+          set -xe
+
+          git clone git@server:${strideTasksRepoPath} ${settingsPath}/repository
+        ''}")
+
+        with subtest("Can sync tasks"):
+          client_send.succeed("stride sync")
+
+        with subtest("Correct tasks were synced"):
+          count_before = client_receive.succeed('stride "" | wc -l')
+          client_send.succeed('stride add "Second task" && stride sync')
+          client_receive.succeed('stride sync')
+          count_after = client_receive.succeed('stride "" | wc -l')
+
+          search_output = client_receive.succeed('stride ""')
+          expected_search_output = "    0: Task 1 of client_send\n    1: Second task\n"
+
+          assert int(count_before) == 1, "Starting from a fresh clone should have 1 tasks"
+          assert int(count_after) == 2, f"Did not receive 2 tasks from sync, but: '{count_after}'"
+          assert search_output == expected_search_output, f"The tasks changed their message? Their new message is: '{search_output}', but we expected: '{expected_search_output}'"
+      '';
+  }

--- a/tests/taskchampion-sync/test.nix
+++ b/tests/taskchampion-sync/test.nix
@@ -1,0 +1,86 @@
+{
+  pkgs,
+  nixos-lib,
+  stride-cli,
+  ...
+}:
+nixos-lib.runTest {
+  hostPkgs = pkgs;
+  name = "taskchampion-sync-server";
+
+  nodes = {
+    server = {config, ...}: {
+      services.taskchampion-sync-server = {
+        enable = true;
+        openFirewall = true;
+      };
+    };
+    stride_client = {config, ...}: {
+      environment.systemPackages = [
+        stride-cli
+      ];
+    };
+    task_client = {config, ...}: {
+      environment.systemPackages = [
+        pkgs.taskwarrior3
+      ];
+    };
+  };
+  testScript = {nodes, ...}: let
+    cfg = nodes.server.services.taskchampion-sync-server;
+    port = builtins.toString cfg.port;
+
+    # Generated with uuidgen
+    uuid = "bf01376e-04a4-435a-9263-608567531af3";
+    password = "nixos-test";
+
+    user-dirs-file = pkgs.writeText "user-dirs.dirs" ''
+      XDG_DOCUMENTS_DIR="/root/Documents"
+    '';
+  in
+    /*
+    python
+    */
+    ''
+      start_all()
+
+      server.wait_for_unit("taskchampion-sync-server.service")
+      server.wait_for_open_port(${port})
+
+      with subtest("Setup task syncing"):
+          # See man task-sync(5)
+          task_client.succeed("mkdir ~/.task")
+          task_client.succeed("touch ~/.taskrc")
+          task_client.succeed("echo sync.server.origin=http://server:${port} >> ~/.taskrc")
+          task_client.succeed("echo sync.server.client_id=${uuid} >> ~/.taskrc")
+          task_client.succeed("echo sync.encryption_secret=${password} >> ~/.taskrc")
+
+          # The `TaskStorage` needs a document dir, which `stride` reads from the
+          # `user-dirs.dirs` file (via the `dirs` crate)
+          stride_client.succeed(
+              "mkdir ~/.config",
+              "cat ${user-dirs-file} > ~/.config/user-dirs.dirs",
+              "mkdir ~/Documents"
+          )
+          stride_client.succeed("touch ~/.taskrc")
+          stride_client.succeed("echo sync.server.origin=http://server:${port} >> ~/.taskrc")
+          stride_client.succeed("echo sync.server.client_id=${uuid} >> ~/.taskrc")
+          stride_client.succeed("echo sync.encryption_secret=${password} >> ~/.taskrc")
+
+      with subtest("Can create tasks"):
+          task_client.succeed("task add 'First task -- task_client'")
+          stride_client.succeed("stride add 'First task -- stride_client'")
+
+      with subtest("Can sync tasks"):
+          task_client.succeed("task sync")
+          stride_client.succeed("stride sync")
+          task_client.succeed("task sync")
+
+      with subtest("Have correct tasks"):
+          count1 = task_client.succeed("task count")
+          count2 = stride_client.succeed('stride "" | wc -l')
+
+          assert int(count1) == 2, f"We don't have exactly 2 tasks, but {count1}"
+          assert count1 == count2, f"The clients don't have the same amount of tasks, stride_client: {count1}, task_client: {count2}"
+    '';
+}

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -1,0 +1,66 @@
+{
+  treefmt-nix,
+  pkgs,
+}:
+treefmt-nix.lib.evalModule pkgs (
+  {pkgs, ...}: {
+    # Used to find the project root
+    projectRootFile = "flake.nix";
+
+    programs = {
+      alejandra.enable = true;
+      rustfmt.enable = true;
+      clang-format.enable = true;
+      mdformat.enable = true;
+      shfmt = {
+        enable = true;
+        indent_size = 4;
+      };
+      shellcheck.enable = true;
+      prettier = {
+        enable = true;
+        settings = {
+          arrowParens = "always";
+          bracketSameLine = false;
+          bracketSpacing = true;
+          editorconfig = true;
+          embeddedLanguageFormatting = "auto";
+          endOfLine = "lf";
+          # experimentalTernaries = false;
+          htmlWhitespaceSensitivity = "css";
+          insertPragma = false;
+          jsxSingleQuote = true;
+          printWidth = 80;
+          proseWrap = "always";
+          quoteProps = "consistent";
+          requirePragma = false;
+          semi = true;
+          singleAttributePerLine = true;
+          singleQuote = false;
+          trailingComma = "all";
+          useTabs = false;
+          vueIndentScriptAndStyle = false;
+
+          tabWidth = 2;
+        };
+      };
+      stylua.enable = true;
+      ruff = {
+        enable = true;
+        format = true;
+      };
+      taplo.enable = true;
+    };
+
+    settings = {
+      formatter = {
+        clang-format = {
+          options = ["--style" "GNU"];
+        };
+        shfmt = {
+          includes = ["*.bash"];
+        };
+      };
+    };
+  }
+)


### PR DESCRIPTION
I've realized, that testing the syncing code is quite hard, as it requires me to run a
server and client *and* ensure that I'm not simplifying stuff, by running both on the same
machine and thus using localhost.

To remedy that, I've opted for the nix based vm tests, which allow me to start three vms,
thus even comparing `stride`'s sync to `task`'s. Besides, the NixOS module makes the
whole setup of the sync server very easy.

I've opened this pr, containing only the nix stuff, as I wanted to make sure,
that you are okay with such an extensive change.