### PR TITLE
ci: Include the nixos vm integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,6 +79,20 @@ jobs:
       - name: Generate documentation
         run: cargo doc -v --document-private-items --all-features
 
+  integration-tests:
+    name: NixOS VM integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout flake
+        uses: actions/checkout@v4
+
+      - name: Install nix
+        uses: DeterminateSystems/nix-installer-action@v9
+
+      - name: Run tests
+        run: |
+          nix --print-build-logs flake check
+
   test-flutter:
     name: Flutter Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes: https://github.com/stride-tasks/stride/issues/42.

Beware that this is the first time, that I used GitHub actions. The tests should now be run on ever push to main and on every opened pull request targeting main. 
Running it on every opened pull request seems useful to me, because that probably helps catch errors early in the pr process (but I am not so sure, whether that is actually useful in the context of GitHub actions). I would like to only run this on ever merge to main (as the original issue already suggested), but there seems to be no [event](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows) for that (see [here](https://github.com/orgs/community/discussions/26724)).