### PR TITLE
Distinct entry date field for task

### DIFF
--- a/app/lib/bridge/api/repository.dart
+++ b/app/lib/bridge/api/repository.dart
@@ -20,6 +20,7 @@ import 'package:stride/bridge/third_party/stride_core/task/annotation.dart';
 import 'package:uuid/uuid.dart';
 
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `fmt`
+// These functions are ignored (category: IgnoreBecauseExplicitAttribute): `database_mut`, `database`, `root_path`
 
 // Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<Repository>>
 abstract class Repository implements RustOpaqueInterface {

--- a/app/lib/bridge/frb_generated.dart
+++ b/app/lib/bridge/frb_generated.dart
@@ -88,7 +88,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.9.0';
 
   @override
-  int get rustContentHash => 1883100118;
+  int get rustContentHash => -1840076236;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -272,8 +272,6 @@ abstract class RustLibApi extends BaseApi {
   Future<List<SshKey>> crateApiSettingsSshKeys();
 
   Future<Task> strideCoreTaskTaskDefault();
-
-  Future<DateTime> strideCoreTaskTaskEntry({required Task that});
 
   Future<Task?> strideCoreTaskTaskFromData({required List<int> input});
 
@@ -2191,37 +2189,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<DateTime> strideCoreTaskTaskEntry({required Task that}) {
-    return handler.executeNormal(NormalTask(
-      callFfi: (port_) {
-        final serializer = SseSerializer(generalizedFrbRustBinding);
-        sse_encode_box_autoadd_task(that, serializer);
-        pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 72, port: port_);
-      },
-      codec: SseCodec(
-        decodeSuccessData: sse_decode_Chrono_Utc,
-        decodeErrorData: null,
-      ),
-      constMeta: kStrideCoreTaskTaskEntryConstMeta,
-      argValues: [that],
-      apiImpl: this,
-    ));
-  }
-
-  TaskConstMeta get kStrideCoreTaskTaskEntryConstMeta => const TaskConstMeta(
-        debugName: 'task_entry',
-        argNames: ['that'],
-      );
-
-  @override
   Future<Task?> strideCoreTaskTaskFromData({required List<int> input}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_list_prim_u_8_loose(input, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 73, port: port_);
+            funcId: 72, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_opt_box_autoadd_task,
@@ -2244,7 +2218,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(title, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 74)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 73)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_task,
@@ -2268,7 +2242,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_task_priority(that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 75, port: port_);
+            funcId: 74, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2292,7 +2266,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 76, port: port_);
+            funcId: 75, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_task_priority,
@@ -2316,7 +2290,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 77, port: port_);
+            funcId: 76, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_task_status,
@@ -2341,7 +2315,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_task_status(that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 78, port: port_);
+            funcId: 77, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -2366,7 +2340,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_task(that, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 79, port: port_);
+            funcId: 78, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_list_prim_u_8_strict,
@@ -2389,7 +2363,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_box_autoadd_task(that, serializer);
-        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 80)!;
+        return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 79)!;
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_f_32,
@@ -2415,7 +2389,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_Uuid(uuid, serializer);
         sse_encode_String(title, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 81, port: port_);
+            funcId: 80, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_task,
@@ -2439,7 +2413,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(pluginName, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 82, port: port_);
+            funcId: 81, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_bool,
@@ -2465,7 +2439,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(message, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 83, port: port_);
+            funcId: 82, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -2489,7 +2463,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(message, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
-            funcId: 84, port: port_);
+            funcId: 83, port: port_);
       },
       codec: SseCodec(
         decodeSuccessData: sse_decode_unit,
@@ -3341,22 +3315,23 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Task dco_decode_task(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 13)
-      throw Exception('unexpected arr length: expect 13 but see ${arr.length}');
+    if (arr.length != 14)
+      throw Exception('unexpected arr length: expect 14 but see ${arr.length}');
     return Task.raw(
       uuid: dco_decode_Uuid(arr[0]),
-      status: dco_decode_task_status(arr[1]),
-      title: dco_decode_String(arr[2]),
-      active: dco_decode_bool(arr[3]),
-      modified: dco_decode_opt_box_autoadd_Chrono_Utc(arr[4]),
-      due: dco_decode_opt_box_autoadd_Chrono_Utc(arr[5]),
-      project: dco_decode_opt_String(arr[6]),
-      tags: dco_decode_list_String(arr[7]),
-      annotations: dco_decode_list_annotation(arr[8]),
-      priority: dco_decode_opt_box_autoadd_task_priority(arr[9]),
-      wait: dco_decode_opt_box_autoadd_Chrono_Utc(arr[10]),
-      depends: dco_decode_list_Uuid(arr[11]),
-      uda: dco_decode_Map_String_String_None(arr[12]),
+      entry: dco_decode_Chrono_Utc(arr[1]),
+      status: dco_decode_task_status(arr[2]),
+      title: dco_decode_String(arr[3]),
+      active: dco_decode_bool(arr[4]),
+      modified: dco_decode_opt_box_autoadd_Chrono_Utc(arr[5]),
+      due: dco_decode_opt_box_autoadd_Chrono_Utc(arr[6]),
+      project: dco_decode_opt_String(arr[7]),
+      tags: dco_decode_list_String(arr[8]),
+      annotations: dco_decode_list_annotation(arr[9]),
+      priority: dco_decode_opt_box_autoadd_task_priority(arr[10]),
+      wait: dco_decode_opt_box_autoadd_Chrono_Utc(arr[11]),
+      depends: dco_decode_list_Uuid(arr[12]),
+      uda: dco_decode_Map_String_String_None(arr[13]),
     );
   }
 
@@ -4346,6 +4321,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Task sse_decode_task(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     final var_uuid = sse_decode_Uuid(deserializer);
+    final var_entry = sse_decode_Chrono_Utc(deserializer);
     final var_status = sse_decode_task_status(deserializer);
     final var_title = sse_decode_String(deserializer);
     final var_active = sse_decode_bool(deserializer);
@@ -4360,6 +4336,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     final var_uda = sse_decode_Map_String_String_None(deserializer);
     return Task.raw(
         uuid: var_uuid,
+        entry: var_entry,
         status: var_status,
         title: var_title,
         active: var_active,
@@ -5276,6 +5253,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_task(Task self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_Uuid(self.uuid, serializer);
+    sse_encode_Chrono_Utc(self.entry, serializer);
     sse_encode_task_status(self.status, serializer);
     sse_encode_String(self.title, serializer);
     sse_encode_bool(self.active, serializer);

--- a/app/lib/bridge/third_party/stride_core/task.dart
+++ b/app/lib/bridge/third_party/stride_core/task.dart
@@ -29,6 +29,7 @@ class Task with _$Task {
   const Task._();
   const factory Task.raw({
     required UuidValue uuid,
+    required DateTime entry,
     required TaskStatus status,
     required String title,
     required bool active,
@@ -44,10 +45,6 @@ class Task with _$Task {
   }) = _Task;
   static Future<Task> default_() =>
       RustLib.instance.api.strideCoreTaskTaskDefault();
-
-  Future<DateTime> entry() => RustLib.instance.api.strideCoreTaskTaskEntry(
-        that: this,
-      );
 
   static Future<Task?> fromData({required List<int> input}) =>
       RustLib.instance.api.strideCoreTaskTaskFromData(input: input);

--- a/app/lib/bridge/third_party/stride_core/task.freezed.dart
+++ b/app/lib/bridge/third_party/stride_core/task.freezed.dart
@@ -17,6 +17,7 @@ final _privateConstructorUsedError = UnsupportedError(
 /// @nodoc
 mixin _$Task {
   UuidValue get uuid => throw _privateConstructorUsedError;
+  DateTime get entry => throw _privateConstructorUsedError;
   TaskStatus get status => throw _privateConstructorUsedError;
   String get title => throw _privateConstructorUsedError;
   bool get active => throw _privateConstructorUsedError;
@@ -33,6 +34,7 @@ mixin _$Task {
   TResult when<TResult extends Object?>({
     required TResult Function(
             UuidValue uuid,
+            DateTime entry,
             TaskStatus status,
             String title,
             bool active,
@@ -52,6 +54,7 @@ mixin _$Task {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(
             UuidValue uuid,
+            DateTime entry,
             TaskStatus status,
             String title,
             bool active,
@@ -71,6 +74,7 @@ mixin _$Task {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(
             UuidValue uuid,
+            DateTime entry,
             TaskStatus status,
             String title,
             bool active,
@@ -117,6 +121,7 @@ abstract class $TaskCopyWith<$Res> {
   @useResult
   $Res call(
       {UuidValue uuid,
+      DateTime entry,
       TaskStatus status,
       String title,
       bool active,
@@ -147,6 +152,7 @@ class _$TaskCopyWithImpl<$Res, $Val extends Task>
   @override
   $Res call({
     Object? uuid = null,
+    Object? entry = null,
     Object? status = null,
     Object? title = null,
     Object? active = null,
@@ -165,6 +171,10 @@ class _$TaskCopyWithImpl<$Res, $Val extends Task>
           ? _value.uuid
           : uuid // ignore: cast_nullable_to_non_nullable
               as UuidValue,
+      entry: null == entry
+          ? _value.entry
+          : entry // ignore: cast_nullable_to_non_nullable
+              as DateTime,
       status: null == status
           ? _value.status
           : status // ignore: cast_nullable_to_non_nullable
@@ -226,6 +236,7 @@ abstract class _$$TaskImplCopyWith<$Res> implements $TaskCopyWith<$Res> {
   @useResult
   $Res call(
       {UuidValue uuid,
+      DateTime entry,
       TaskStatus status,
       String title,
       bool active,
@@ -253,6 +264,7 @@ class __$$TaskImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? uuid = null,
+    Object? entry = null,
     Object? status = null,
     Object? title = null,
     Object? active = null,
@@ -271,6 +283,10 @@ class __$$TaskImplCopyWithImpl<$Res>
           ? _value.uuid
           : uuid // ignore: cast_nullable_to_non_nullable
               as UuidValue,
+      entry: null == entry
+          ? _value.entry
+          : entry // ignore: cast_nullable_to_non_nullable
+              as DateTime,
       status: null == status
           ? _value.status
           : status // ignore: cast_nullable_to_non_nullable
@@ -328,6 +344,7 @@ class __$$TaskImplCopyWithImpl<$Res>
 class _$TaskImpl extends _Task {
   const _$TaskImpl(
       {required this.uuid,
+      required this.entry,
       required this.status,
       required this.title,
       required this.active,
@@ -348,6 +365,8 @@ class _$TaskImpl extends _Task {
 
   @override
   final UuidValue uuid;
+  @override
+  final DateTime entry;
   @override
   final TaskStatus status;
   @override
@@ -398,7 +417,7 @@ class _$TaskImpl extends _Task {
 
   @override
   String toString() {
-    return 'Task.raw(uuid: $uuid, status: $status, title: $title, active: $active, modified: $modified, due: $due, project: $project, tags: $tags, annotations: $annotations, priority: $priority, wait: $wait, depends: $depends, uda: $uda)';
+    return 'Task.raw(uuid: $uuid, entry: $entry, status: $status, title: $title, active: $active, modified: $modified, due: $due, project: $project, tags: $tags, annotations: $annotations, priority: $priority, wait: $wait, depends: $depends, uda: $uda)';
   }
 
   @override
@@ -407,6 +426,7 @@ class _$TaskImpl extends _Task {
         (other.runtimeType == runtimeType &&
             other is _$TaskImpl &&
             (identical(other.uuid, uuid) || other.uuid == uuid) &&
+            (identical(other.entry, entry) || other.entry == entry) &&
             (identical(other.status, status) || other.status == status) &&
             (identical(other.title, title) || other.title == title) &&
             (identical(other.active, active) || other.active == active) &&
@@ -428,6 +448,7 @@ class _$TaskImpl extends _Task {
   int get hashCode => Object.hash(
       runtimeType,
       uuid,
+      entry,
       status,
       title,
       active,
@@ -454,6 +475,7 @@ class _$TaskImpl extends _Task {
   TResult when<TResult extends Object?>({
     required TResult Function(
             UuidValue uuid,
+            DateTime entry,
             TaskStatus status,
             String title,
             bool active,
@@ -468,7 +490,7 @@ class _$TaskImpl extends _Task {
             Map<String, String> uda)
         raw,
   }) {
-    return raw(uuid, status, title, active, modified, due, project, tags,
+    return raw(uuid, entry, status, title, active, modified, due, project, tags,
         annotations, priority, wait, depends, uda);
   }
 
@@ -477,6 +499,7 @@ class _$TaskImpl extends _Task {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(
             UuidValue uuid,
+            DateTime entry,
             TaskStatus status,
             String title,
             bool active,
@@ -491,8 +514,8 @@ class _$TaskImpl extends _Task {
             Map<String, String> uda)?
         raw,
   }) {
-    return raw?.call(uuid, status, title, active, modified, due, project, tags,
-        annotations, priority, wait, depends, uda);
+    return raw?.call(uuid, entry, status, title, active, modified, due, project,
+        tags, annotations, priority, wait, depends, uda);
   }
 
   @override
@@ -500,6 +523,7 @@ class _$TaskImpl extends _Task {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(
             UuidValue uuid,
+            DateTime entry,
             TaskStatus status,
             String title,
             bool active,
@@ -516,8 +540,8 @@ class _$TaskImpl extends _Task {
     required TResult orElse(),
   }) {
     if (raw != null) {
-      return raw(uuid, status, title, active, modified, due, project, tags,
-          annotations, priority, wait, depends, uda);
+      return raw(uuid, entry, status, title, active, modified, due, project,
+          tags, annotations, priority, wait, depends, uda);
     }
     return orElse();
   }
@@ -554,6 +578,7 @@ class _$TaskImpl extends _Task {
 abstract class _Task extends Task {
   const factory _Task(
       {required final UuidValue uuid,
+      required final DateTime entry,
       required final TaskStatus status,
       required final String title,
       required final bool active,
@@ -570,6 +595,8 @@ abstract class _Task extends Task {
 
   @override
   UuidValue get uuid;
+  @override
+  DateTime get entry;
   @override
   TaskStatus get status;
   @override

--- a/app/lib/routes/task_route.dart
+++ b/app/lib/routes/task_route.dart
@@ -162,6 +162,7 @@ class _TaskRouteState extends State<TaskRoute> {
             final task = Task.raw(
               uuid:
                   widget.task?.uuid ?? UuidValue.fromString(const Uuid().v7()),
+              entry: DateTime.now().toUtc(),
               title: title,
               active: active,
               tags: _tags,

--- a/crates/backend/src/taskchampion/mod.rs
+++ b/crates/backend/src/taskchampion/mod.rs
@@ -95,7 +95,7 @@ impl TaskchampionBackend {
 
         let mut champion_task = self.source.create_task(task.uuid, &mut self.operations)?;
 
-        champion_task.set_entry(Some(task.entry()), &mut self.operations)?;
+        champion_task.set_entry(Some(task.entry), &mut self.operations)?;
         champion_task.set_description(task.title, &mut self.operations)?;
         champion_task.set_due(task.due, &mut self.operations)?;
         champion_task.set_wait(task.wait, &mut self.operations)?;

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -152,7 +152,7 @@ impl Database {
     fn row_to_task(row: &Row<'_>) -> Result<Task, rusqlite::Error> {
         let uuid = row.get::<_, Uuid>("id")?;
         let title = row.get::<_, String>("title")?;
-        let _entry = row.get::<_, Sql<Date>>("entry")?.value;
+        let entry = row.get::<_, Sql<Date>>("entry")?.value;
         let mut status = row.get::<_, Sql<TaskStatus>>("status")?.value;
         let priority = row.get::<_, Sql<Option<TaskPriority>>>("priority")?.value;
         let project = row.get::<_, Option<String>>("project")?;
@@ -171,6 +171,7 @@ impl Database {
 
         Ok(Task {
             uuid,
+            entry,
             status,
             title,
             active: false,
@@ -284,7 +285,7 @@ impl Database {
         sql.execute::<&[(&str, &dyn ToSql)]>(&[
             (":id", &task_uuid),
             (":title", &task.title),
-            (":entry", &Sql::from(task.entry())),
+            (":entry", &Sql::from(task.entry)),
             (":status", &Sql::from(task.status)),
             (":priority", &Sql::from(task.priority)),
             (":project", &task.project),
@@ -322,7 +323,7 @@ impl Database {
         sql.execute::<&[(&str, &dyn ToSql)]>(&[
             (":id", &task.uuid),
             (":title", &task.title),
-            (":entry", &Sql::from(task.entry())),
+            (":entry", &Sql::from(task.entry)),
             (":status", &Sql::from(task.status)),
             (":priority", &Sql::from(task.priority)),
             (":project", &task.project),

--- a/crates/flutter_bridge/src/frb_generated.rs
+++ b/crates/flutter_bridge/src/frb_generated.rs
@@ -42,7 +42,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.9.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1883100118;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1840076236;
 
 // Section: executor
 
@@ -2768,39 +2768,6 @@ fn wire__stride_core__task__task_default_impl(
         },
     )
 }
-fn wire__stride_core__task__task_entry_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "task_entry",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_that = <stride_core::task::Task>::sse_decode(&mut deserializer);
-            deserializer.end();
-            move |context| {
-                transform_result_sse::<_, ()>((move || {
-                    let output_ok = Result::<_, ()>::Ok(stride_core::task::Task::entry(&api_that))?;
-                    Ok(output_ok)
-                })())
-            }
-        },
-    )
-}
 fn wire__stride_core__task__task_from_data_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -3302,6 +3269,7 @@ const _: fn() = || {
     {
         let Task = None::<stride_core::task::Task>.unwrap();
         let _: uuid::Uuid = Task.uuid;
+        let _: chrono::DateTime<chrono::Utc> = Task.entry;
         let _: stride_core::task::TaskStatus = Task.status;
         let _: String = Task.title;
         let _: bool = Task.active;
@@ -4228,6 +4196,7 @@ impl SseDecode for stride_core::task::Task {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_uuid = <uuid::Uuid>::sse_decode(deserializer);
+        let mut var_entry = <chrono::DateTime<chrono::Utc>>::sse_decode(deserializer);
         let mut var_status = <stride_core::task::TaskStatus>::sse_decode(deserializer);
         let mut var_title = <String>::sse_decode(deserializer);
         let mut var_active = <bool>::sse_decode(deserializer);
@@ -4243,6 +4212,7 @@ impl SseDecode for stride_core::task::Task {
         let mut var_uda = <std::collections::HashMap<String, String>>::sse_decode(deserializer);
         return stride_core::task::Task {
             uuid: var_uuid,
+            entry: var_entry,
             status: var_status,
             title: var_title,
             active: var_active,
@@ -4531,21 +4501,20 @@ fn pde_ffi_dispatcher_primary_impl(
         69 => wire__crate__api__settings__settings_save_impl(port, ptr, rust_vec_len, data_len),
         70 => wire__crate__api__settings__ssh_keys_impl(port, ptr, rust_vec_len, data_len),
         71 => wire__stride_core__task__task_default_impl(port, ptr, rust_vec_len, data_len),
-        72 => wire__stride_core__task__task_entry_impl(port, ptr, rust_vec_len, data_len),
-        73 => wire__stride_core__task__task_from_data_impl(port, ptr, rust_vec_len, data_len),
-        75 => wire__stride_core__task__task_priority_as_str_impl(port, ptr, rust_vec_len, data_len),
-        76 => {
+        72 => wire__stride_core__task__task_from_data_impl(port, ptr, rust_vec_len, data_len),
+        74 => wire__stride_core__task__task_priority_as_str_impl(port, ptr, rust_vec_len, data_len),
+        75 => {
             wire__stride_core__task__task_priority_default_impl(port, ptr, rust_vec_len, data_len)
         }
-        77 => wire__stride_core__task__task_status_default_impl(port, ptr, rust_vec_len, data_len),
-        78 => {
+        76 => wire__stride_core__task__task_status_default_impl(port, ptr, rust_vec_len, data_len),
+        77 => {
             wire__stride_core__task__task_status_is_pending_impl(port, ptr, rust_vec_len, data_len)
         }
-        79 => wire__stride_core__task__task_to_data_impl(port, ptr, rust_vec_len, data_len),
-        81 => wire__stride_core__task__task_with_uuid_impl(port, ptr, rust_vec_len, data_len),
-        82 => wire__crate__api__plugin_manager__toggle_impl(port, ptr, rust_vec_len, data_len),
-        83 => wire__crate__api__logging__trace_impl(port, ptr, rust_vec_len, data_len),
-        84 => wire__crate__api__logging__warn_impl(port, ptr, rust_vec_len, data_len),
+        78 => wire__stride_core__task__task_to_data_impl(port, ptr, rust_vec_len, data_len),
+        80 => wire__stride_core__task__task_with_uuid_impl(port, ptr, rust_vec_len, data_len),
+        81 => wire__crate__api__plugin_manager__toggle_impl(port, ptr, rust_vec_len, data_len),
+        82 => wire__crate__api__logging__trace_impl(port, ptr, rust_vec_len, data_len),
+        83 => wire__crate__api__logging__warn_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -4612,8 +4581,8 @@ fn pde_ffi_dispatcher_sync_impl(
             data_len,
         ),
         68 => wire__crate__api__settings__settings_new_impl(ptr, rust_vec_len, data_len),
-        74 => wire__stride_core__task__task_new_impl(ptr, rust_vec_len, data_len),
-        80 => wire__stride_core__task__task_urgency_impl(ptr, rust_vec_len, data_len),
+        73 => wire__stride_core__task__task_new_impl(ptr, rust_vec_len, data_len),
+        79 => wire__stride_core__task__task_urgency_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -5191,6 +5160,7 @@ impl flutter_rust_bridge::IntoDart for FrbWrapper<stride_core::task::Task> {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
             self.0.uuid.into_into_dart().into_dart(),
+            self.0.entry.into_into_dart().into_dart(),
             self.0.status.into_into_dart().into_dart(),
             self.0.title.into_into_dart().into_dart(),
             self.0.active.into_into_dart().into_dart(),
@@ -6033,6 +6003,7 @@ impl SseEncode for stride_core::task::Task {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <uuid::Uuid>::sse_encode(self.uuid, serializer);
+        <chrono::DateTime<chrono::Utc>>::sse_encode(self.entry, serializer);
         <stride_core::task::TaskStatus>::sse_encode(self.status, serializer);
         <String>::sse_encode(self.title, serializer);
         <bool>::sse_encode(self.active, serializer);

--- a/crates/plugin_manager/src/manager.rs
+++ b/crates/plugin_manager/src/manager.rs
@@ -168,7 +168,7 @@ impl PluginManager {
                 }
             }
             _ => {}
-        };
+        }
 
         Some(PluginAction::Event {
             plugin_name: manifest.name,


### PR DESCRIPTION
This PR splits the entry date, which was extracted from the UUIDv7 task id, this had issue which forced to always store UUIDv7, any any UUIDs would not work, this makes integration with taskchampion more difficult since we can't ensure that it's always UUIDv7.

This is a breaking change with the old git format, and uses another 8 bytes in the encoding.