### PR TITLE
Lock cargokit dependencies for reporducible builds

### DIFF
--- a/app/rust_builder/cargokit/build_tool/lib/src/builder.dart
+++ b/app/rust_builder/cargokit/build_tool/lib/src/builder.dart
@@ -148,6 +148,7 @@ class RustBuilder {
         _toolchain,
         'cargo',
         'build',
+        '--locked',
         ...extraArgs,
         '--manifest-path',
         manifestPath,


### PR DESCRIPTION
Fixes #81 
