### PR TITLE
Implement configurable backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1852,17 +1852,16 @@ name = "stride_cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64",
  "chrono",
  "clap",
  "dirs 6.0.0",
  "log",
- "serde",
  "stride_backend",
  "stride_core",
  "stride_database",
  "stride_flutter_bridge",
  "stride_plugin_manager",
- "toml",
  "url",
  "uuid",
 ]
@@ -1872,10 +1871,13 @@ name = "stride_core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64",
  "chrono",
  "serde",
  "serde_json",
  "taskchampion",
+ "thiserror 2.0.12",
+ "url",
  "uuid",
 ]
 
@@ -1895,6 +1897,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "rusqlite",
+ "serde_json",
  "stride_core",
  "thiserror 2.0.12",
  "uuid",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,8 +25,7 @@ dirs.workspace = true
 uuid.workspace = true
 log.workspace = true
 clap.workspace = true
-toml.workspace = true
-serde.workspace = true
+base64.workspace = true
 url.workspace = true
 
 [[bin]]

--- a/cli/src/backend.rs
+++ b/cli/src/backend.rs
@@ -1,0 +1,177 @@
+use std::process::ExitCode;
+
+use anyhow::{Context, bail};
+use base64::Engine;
+use stride_core::{
+    backend::{BackendRecord, Value},
+    state::KnownPaths,
+};
+use stride_flutter_bridge::api::{repository::Repository, settings::ssh_keys};
+use url::Url;
+use uuid::Uuid;
+
+use crate::{cli::BackendCommand, get_backend_registry};
+
+// TODO: Remove lints.
+#[allow(clippy::missing_panics_doc)]
+#[allow(clippy::too_many_lines)]
+pub(crate) fn handle_command(
+    command: Option<&BackendCommand>,
+    repository: &mut Repository,
+    known_paths: &KnownPaths,
+) -> anyhow::Result<ExitCode> {
+    let registry = get_backend_registry(known_paths)?;
+
+    match command {
+        None | Some(BackendCommand::List) => {
+            let backends = repository.database().lock().unwrap().backends()?;
+            for (i, backend) in backends.iter().enumerate() {
+                println!("{i:2}. {}", backend.name);
+            }
+        }
+        Some(BackendCommand::New { backend_name: name }) => {
+            let Some(handler) = registry.get(name.as_str()) else {
+                bail!("unknown backend name: {name}");
+            };
+            let record = BackendRecord {
+                id: Uuid::now_v7(),
+                enabled: true,
+                name: handler.name(),
+                config: handler.config_schema().as_config(),
+            };
+            repository
+                .database()
+                .lock()
+                .unwrap()
+                .add_backends(&record)?;
+        }
+        Some(BackendCommand::Config {
+            backend_name: name,
+            property_name,
+            unset,
+            property_value,
+        }) => {
+            let mut backends = repository.database().lock().unwrap().backends()?;
+
+            let backend = backends
+                .iter_mut()
+                .find(|backend_record| backend_record.name.contains(name))
+                .with_context(|| format!("Could not find field with name {name}"))?;
+
+            let Some(handler) = registry.get(name.as_str()) else {
+                bail!("unknown backend name: {name}");
+            };
+
+            let config = backend.config.align(&handler.config_schema())?;
+            if config != backend.config {
+                backend.config = config;
+                repository
+                    .database()
+                    .lock()
+                    .unwrap()
+                    .update_backend(backend)?;
+            }
+
+            let Some(property_name) = property_name else {
+                for (id, value) in &backend.config.fields {
+                    let required = if value.is_some() { "*" } else { "" };
+                    println!("{id}: {}{required} = {}", value.as_type_name(), value);
+                }
+                return Ok(ExitCode::SUCCESS);
+            };
+
+            let value = backend
+                .config
+                .find_field_mut(property_name)
+                .with_context(|| format!("Could not find field with name {property_name}"))?;
+
+            let Some(property_value) = property_value else {
+                if *unset {
+                    assert!(
+                        property_value.is_none(),
+                        "connot unset with specifying value"
+                    );
+
+                    match value {
+                        Value::Uuid(value) | Value::SshKey(value) => *value = None,
+                        Value::String(value) => *value = None,
+                        Value::Bytes(value) | Value::Encryption { value, .. } => {
+                            *value = None;
+                        }
+                        Value::Url(value) => *value = None,
+                    }
+
+                    return Ok(ExitCode::SUCCESS);
+                }
+
+                let has_value = value.is_some();
+                if has_value {
+                    println!("{value}");
+                }
+
+                repository
+                    .database_mut()
+                    .get_mut()
+                    .unwrap()
+                    .update_backend(backend)?;
+
+                return Ok(ExitCode::from(u8::from(!has_value)));
+            };
+
+            match value {
+                Value::Uuid(value) => {
+                    *value = Some(Uuid::parse_str(property_value)?);
+                }
+                Value::String(value) => {
+                    *value = Some(property_value.clone().into_boxed_str());
+                }
+                Value::Bytes(value) => {
+                    *value = Some(property_value.as_bytes().into());
+                }
+                Value::Url(value) => {
+                    *value =
+                        Some(Url::parse(property_value).context("config input has invalid URL")?);
+                }
+                Value::Encryption { mode: _, value } => {
+                    let key = base64::engine::general_purpose::URL_SAFE_NO_PAD
+                        .decode(property_value)
+                        .context("invalid base64 encryption key")?;
+
+                    *value = Some(key.into_boxed_slice());
+                }
+                Value::SshKey(value) => {
+                    let id = Uuid::parse_str(property_value)?;
+
+                    let ssh_keys = ssh_keys()?;
+                    let ssh_key = ssh_keys
+                        .iter()
+                        .find(|ssh_key| ssh_key.uuid() == id)
+                        .with_context(|| format!("could not find ssh key with uuid: {id}"))?;
+
+                    *value = Some(ssh_key.uuid());
+                }
+            }
+
+            repository
+                .database_mut()
+                .get_mut()
+                .unwrap()
+                .update_backend(backend)?;
+        }
+        Some(BackendCommand::Remove { backend_name }) => {
+            let backends = repository.database().lock().unwrap().backends()?;
+
+            let backend = backends
+                .iter()
+                .find(|backend_record| backend_record.name.contains(backend_name))
+                .with_context(|| format!("Could not find field with name {backend_name}"))?;
+
+            repository
+                .database_mut()
+                .get_mut()
+                .unwrap()
+                .delete_backend(backend.id)?;
+        }
+    }
+    Ok(ExitCode::SUCCESS)
+}

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -53,9 +53,7 @@ pub enum Mode {
     /// Sync the task storage
     Sync {
         /// Choose backend to sync.
-        ///
-        /// If `None` then all backends are choosen.
-        backend: Backend,
+        backend: String,
     },
 
     /// Output the git-log of the task storage
@@ -86,10 +84,17 @@ pub enum Mode {
         uuid: Uuid,
     },
 
+    /// Manage backends.
+    Backend {
+        /// Backend command to apply.
+        #[command(subcommand)]
+        command: Option<BackendCommand>,
+    },
+
     /// Manage plugins.
     Plugin {
-        #[command(subcommand)]
         /// Plugin command to apply.
+        #[command(subcommand)]
         command: Option<PluginCommand>,
     },
 
@@ -98,6 +103,38 @@ pub enum Mode {
         /// SSH command to apply.
         #[command(subcommand)]
         command: SshCommand,
+    },
+}
+
+/// Backend command/action to apply.
+#[derive(Debug, Clone, Subcommand)]
+pub enum BackendCommand {
+    /// list backends
+    List,
+    /// Create a new backend.
+    New {
+        /// The name of the backend to be created.
+        backend_name: String,
+    },
+    /// Remove a backend backend.
+    Remove {
+        /// The name of the backend to be removed.
+        backend_name: String,
+    },
+    /// Configure a backend option.
+    Config {
+        /// Name of backend to configure.
+        backend_name: String,
+
+        /// Property name.
+        property_name: Option<String>,
+
+        /// Unset a property.
+        #[clap(long, conflicts_with = "property_value")]
+        unset: bool,
+
+        /// Property name.
+        property_value: Option<String>,
     },
 }
 

--- a/crates/backend/src/error.rs
+++ b/crates/backend/src/error.rs
@@ -51,6 +51,9 @@ pub enum Error {
 
     #[error("database error: {0}")]
     Database(#[from] stride_database::Error),
+
+    #[error("config error: {0}")]
+    Config(#[from] stride_core::backend::Error),
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/crates/backend/src/git/config.rs
+++ b/crates/backend/src/git/config.rs
@@ -1,6 +1,70 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+use base64::Engine;
+use stride_core::{
+    backend::{Config, EncryptionMode, Schema, Value},
+    state::KnownPaths,
+};
+
+use crate::{Backend, BackendHandler, git::GitBackend};
 
 use super::{encryption_key::EncryptionKey, ssh_key::SshKey};
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Handler;
+
+impl BackendHandler for Handler {
+    fn name(&self) -> Box<str> {
+        "git".into()
+    }
+
+    fn config_schema(&self) -> Schema {
+        Schema::builder(self.name())
+            .field("origin", "Origin", Value::String(None))
+            .field("author", "Author", Value::string("Stride"))
+            .field(
+                "email",
+                "E-mail",
+                Value::string("noreply.stride.tasks@gmail.com"),
+            )
+            .field("branch", "Git Branch", Value::String(Some("main".into())))
+            .field(
+                "encryption_key",
+                "Encryption Key",
+                Value::Encryption {
+                    mode: EncryptionMode::AesOcb256,
+                    value: None,
+                },
+            )
+            .field("ssh_key", "SSH Key", Value::SshKey(None))
+            .build()
+    }
+
+    fn create(
+        &self,
+        config: &Config,
+        path: &Path,
+        known_paths: &KnownPaths,
+    ) -> crate::Result<Box<dyn Backend>> {
+        let config = GitConfig {
+            root_path: path.to_path_buf(),
+            author: config.string_value("author")?.into(),
+            email: config.string_value("email")?.into(),
+            branch: config.string_value("branch")?.into(),
+            origin: config.string_value("origin")?.into(),
+            encryption_key: EncryptionKey {
+                key: base64::engine::general_purpose::URL_SAFE_NO_PAD
+                    .encode(config.encryption_aes_ocb_256("encryption_key")?),
+            },
+            ssh_key: {
+                let id = config.ssh_key_value("ssh_key")?;
+                SshKey::load_key(id, known_paths)?
+            },
+        };
+
+        Ok(Box::new(GitBackend::new(config)?))
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct GitConfig {

--- a/crates/backend/src/git/mod.rs
+++ b/crates/backend/src/git/mod.rs
@@ -35,7 +35,7 @@ pub mod ssh_key;
 
 use key_store::KeyStore;
 
-use crate::{Backend, Error, Result, ToBase64, base64_decode};
+use crate::{Backend, Error, Result, ToBase64, base64_decode, git::config::Handler};
 
 pub(crate) const IV_LEN: usize = 12;
 
@@ -918,6 +918,13 @@ impl GitBackend {
 }
 
 impl Backend for GitBackend {
+    fn handler() -> Box<dyn crate::BackendHandler>
+    where
+        Self: Sized,
+    {
+        Box::new(Handler)
+    }
+
     fn sync(&mut self, db: &mut Database) -> Result<()> {
         let tasks = db.all_tasks()?;
 

--- a/crates/backend/src/git/ssh_key.rs
+++ b/crates/backend/src/git/ssh_key.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use stride_core::state::KnownPaths;
 use uuid::Uuid;
 
 use crate::Result;
@@ -13,6 +14,61 @@ pub struct SshKey {
 }
 
 impl SshKey {
+    pub fn load_keys(known_path: &KnownPaths) -> Result<Vec<SshKey>> {
+        let ssh_key_path = &known_path.ssh_keys;
+        let Ok(entries) = ssh_key_path.read_dir() else {
+            return Ok(Vec::new());
+        };
+
+        let mut result = Vec::new();
+        for entry in entries {
+            let Ok(entry) = entry else {
+                continue;
+            };
+
+            let Ok(name) = entry.file_name().into_string() else {
+                continue;
+            };
+
+            let Ok(uuid) = Uuid::try_parse(&name) else {
+                continue;
+            };
+
+            let key_path = ssh_key_path.join(uuid.to_string());
+            let public_path = key_path.join("key.pub");
+            let private_path = key_path.join("key");
+
+            let public_key = std::fs::read_to_string(&public_path)
+                .unwrap_or_else(|_| panic!("missing public key in {uuid} SSH key"));
+
+            result.push(SshKey {
+                uuid,
+                public_key,
+                public_path,
+                private_path,
+            });
+        }
+
+        Ok(result)
+    }
+
+    pub fn load_key(uuid: Uuid, known_path: &KnownPaths) -> Result<SshKey, std::io::Error> {
+        let ssh_key_path = &known_path.ssh_keys;
+
+        let key_path = ssh_key_path.join(uuid.to_string());
+        let public_path = key_path.join("key.pub");
+        let private_path = key_path.join("key");
+
+        let public_key = std::fs::read_to_string(&public_path)?;
+
+        Ok(SshKey {
+            uuid,
+            public_key,
+            public_path,
+            private_path,
+        })
+    }
+
     pub fn generate(keys_path: &Path) -> Result<Self> {
         let keys = stride_crypto::ed25519::Ed25519::generate();
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -15,14 +15,19 @@ publish = false
 serde.workspace = true
 uuid.workspace = true
 chrono.workspace = true
+
+thiserror = { workspace = true, optional = true }
+base64 = { workspace = true, optional = true }
 taskchampion = { workspace = true, optional = true }
+url = { workspace = true, features = ["serde"], optional = true }
 
 [dev-dependencies]
 anyhow.workspace = true
 serde_json.workspace = true
 
 [features]
-default = ["taskchampion"]
+default = ["backend", "taskchampion"]
+backend = ["dep:base64", "dep:url", "dep:thiserror"]
 taskchampion = ["dep:taskchampion"]
 
 [lints]

--- a/crates/core/src/backend/mod.rs
+++ b/crates/core/src/backend/mod.rs
@@ -1,0 +1,350 @@
+use std::{
+    collections::HashMap,
+    fmt::{Debug, Display},
+};
+
+use base64::Engine;
+use url::Url;
+use uuid::Uuid;
+
+// TODO: add a Config builder.
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct SchemaBuilder {
+    id: Box<str>,
+    fields: HashMap<Box<str>, SchemaField>,
+}
+
+impl SchemaBuilder {
+    pub fn new<T>(id: T) -> Self
+    where
+        T: Into<Box<str>>,
+    {
+        Self {
+            id: id.into(),
+            fields: HashMap::default(),
+        }
+    }
+
+    /// # Panics
+    ///
+    /// If the same is field is passed twice.
+    #[must_use]
+    pub fn field<T, U, D>(mut self, id: T, name: U, default: D) -> Self
+    where
+        T: Into<Box<str>>,
+        U: Into<Box<str>>,
+        D: Into<Value>,
+    {
+        let id = id.into();
+        let name = name.into();
+
+        let inserted = self.fields.insert(
+            id.clone(),
+            SchemaField {
+                name,
+                default: default.into(),
+            },
+        );
+        assert!(inserted.is_none(), "field added twice: {id}");
+        self
+    }
+
+    #[must_use]
+    pub fn build(self) -> Schema {
+        Schema {
+            name: self.id,
+            fields: self.fields,
+        }
+    }
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct Schema {
+    pub name: Box<str>,
+    pub fields: HashMap<Box<str>, SchemaField>,
+}
+
+impl Schema {
+    pub fn builder<T>(id: T) -> SchemaBuilder
+    where
+        T: Into<Box<str>>,
+    {
+        SchemaBuilder::new(id)
+    }
+
+    #[must_use]
+    pub fn as_config(&self) -> Config {
+        let mut fields = HashMap::new();
+        for (id, field) in &self.fields {
+            fields.insert(id.clone(), field.default.clone());
+        }
+        Config { fields }
+    }
+
+    #[must_use]
+    pub fn field(&self, id: &str) -> Option<&SchemaField> {
+        self.fields.get(id)
+    }
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct SchemaField {
+    pub name: Box<str>,
+    pub default: Value,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("missing schema field: {id}")]
+    MissingField { id: Box<str> },
+    #[error("missing schema field value: {id}")]
+    MissingValue { id: Box<str> },
+    #[error("type mismatch schema field: expected: {expected}, got: {actual}")]
+    TypeMismatch {
+        expected: Box<str>,
+        actual: Box<str>,
+    },
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum EncryptionMode {
+    AesOcb256,
+}
+
+impl EncryptionMode {
+    #[must_use]
+    pub fn as_type_name(&self) -> &str {
+        match self {
+            EncryptionMode::AesOcb256 => "AES(OCB256)",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[serde(tag = "type", content = "content")]
+pub enum Value {
+    String(#[serde(default)] Option<Box<str>>),
+    Uuid(#[serde(default)] Option<Uuid>),
+    Bytes(#[serde(default)] Option<Box<[u8]>>),
+    Url(#[serde(default)] Option<Url>),
+    Encryption {
+        mode: EncryptionMode,
+        #[serde(default)]
+        value: Option<Box<[u8]>>,
+    },
+    SshKey(#[serde(default)] Option<Uuid>),
+}
+
+impl Display for Value {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Value::String(value) => match value {
+                Some(value) => Debug::fmt(value, f),
+                None => f.write_str("none"),
+            },
+            Value::Uuid(uuid) | Value::SshKey(uuid) => match uuid {
+                Some(uuid) => Display::fmt(uuid, f),
+                None => f.write_str("none"),
+            },
+            Value::Bytes(value) | Value::Encryption { value, .. } => match value {
+                Some(value) => {
+                    let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(value);
+                    Display::fmt(&encoded, f)
+                }
+                None => f.write_str("none"),
+            },
+            Value::Url(value) => match value {
+                Some(url) => Display::fmt(url, f),
+                None => f.write_str("none"),
+            },
+        }
+    }
+}
+
+impl Value {
+    #[must_use]
+    pub fn as_type_name(&self) -> &str {
+        match self {
+            Value::String(_) => "string",
+            Value::Uuid(_) => "uuid",
+            Value::Bytes(_) => "bytes",
+            Value::Url(_) => "url",
+            Value::Encryption { mode, .. } => mode.as_type_name(),
+            Value::SshKey(_) => "ssh",
+        }
+    }
+
+    pub fn string<T>(value: T) -> Self
+    where
+        T: Into<Box<str>>,
+    {
+        Self::String(Some(value.into()))
+    }
+
+    #[must_use]
+    pub fn is_some(&self) -> bool {
+        match self {
+            Value::String(None)
+            | Value::Uuid(None)
+            | Value::Bytes(None)
+            | Value::Url(None)
+            | Value::Encryption { value: None, .. }
+            | Value::SshKey(None) => false,
+            Value::String(_)
+            | Value::Uuid(_)
+            | Value::Bytes(_)
+            | Value::Url(_)
+            | Value::Encryption { .. }
+            | Value::SshKey(_) => true,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct Config {
+    pub fields: HashMap<Box<str>, Value>,
+}
+
+impl Config {
+    pub fn value(&self, id: &str) -> Result<&Value, Error> {
+        let Some(field) = self.fields.get(id) else {
+            return Err(Error::MissingField { id: id.into() });
+        };
+        Ok(field)
+    }
+
+    pub fn string_value(&self, name: &str) -> Result<&str, Error> {
+        let value = self.value(name)?;
+        let Value::String(value) = value else {
+            return Err(Error::TypeMismatch {
+                expected: "string".into(),
+                actual: value.as_type_name().into(),
+            });
+        };
+        let value = value
+            .as_ref()
+            .ok_or_else(|| Error::MissingValue { id: name.into() })?;
+        Ok(value)
+    }
+
+    pub fn url_value(&self, name: &str) -> Result<&Url, Error> {
+        let value = self.value(name)?;
+        let Value::Url(value) = value else {
+            return Err(Error::TypeMismatch {
+                expected: "url".into(),
+                actual: value.as_type_name().into(),
+            });
+        };
+        let value = value
+            .as_ref()
+            .ok_or_else(|| Error::MissingValue { id: name.into() })?;
+        Ok(value)
+    }
+
+    pub fn encryption_aes_ocb_256(&self, name: &str) -> Result<&[u8], Error> {
+        let value = self.value(name)?;
+        let Value::Encryption {
+            value,
+            mode: EncryptionMode::AesOcb256,
+        } = value
+        else {
+            return Err(Error::TypeMismatch {
+                expected: EncryptionMode::AesOcb256.as_type_name().into(),
+                actual: value.as_type_name().into(),
+            });
+        };
+        let value = value
+            .as_ref()
+            .ok_or_else(|| Error::MissingValue { id: name.into() })?;
+        Ok(value)
+    }
+
+    pub fn uuid_value(&self, name: &str) -> Result<Uuid, Error> {
+        let value = self.value(name)?;
+        let Value::Uuid(value) = value else {
+            return Err(Error::TypeMismatch {
+                expected: "uuid".into(),
+                actual: value.as_type_name().into(),
+            });
+        };
+        let value = value.ok_or_else(|| Error::MissingValue { id: name.into() })?;
+        Ok(value)
+    }
+
+    pub fn bytes_value(&self, name: &str) -> Result<&[u8], Error> {
+        let value = self.value(name)?;
+        let Value::Bytes(value) = value else {
+            return Err(Error::TypeMismatch {
+                expected: "bytes".into(),
+                actual: value.as_type_name().into(),
+            });
+        };
+        let value = value
+            .as_ref()
+            .ok_or_else(|| Error::MissingValue { id: name.into() })?;
+        Ok(value)
+    }
+
+    // TODO: Make this take the known paths.
+    pub fn ssh_key_value(&self, name: &str) -> Result<Uuid, Error> {
+        let value = self.value(name)?;
+        let Value::SshKey(value) = value else {
+            return Err(Error::TypeMismatch {
+                expected: "ssh_key".into(),
+                actual: value.as_type_name().into(),
+            });
+        };
+        let value = value.ok_or_else(|| Error::MissingValue { id: name.into() })?;
+        Ok(value)
+    }
+
+    pub fn find_field_mut(&mut self, id: &str) -> Option<&mut Value> {
+        self.fields.get_mut(id)
+    }
+
+    pub fn align(&self, schema: &Schema) -> Result<Config, Error> {
+        let mut config = Config {
+            fields: HashMap::default(),
+        };
+
+        for (id, field) in &schema.fields {
+            let Ok(value) = self.value(id) else {
+                config.fields.insert(id.clone(), field.default.clone());
+                continue;
+            };
+
+            let has_value = !matches!(
+                value,
+                Value::String(None)
+                    | Value::Uuid(None)
+                    | Value::Bytes(None)
+                    | Value::Url(None)
+                    | Value::Encryption { value: None, .. }
+                    | Value::SshKey(None)
+            );
+
+            // TODO: check if the property matches types.
+
+            if has_value {
+                config.fields.insert(id.clone(), value.clone());
+            } else {
+                config.fields.insert(id.clone(), field.default.clone());
+            }
+        }
+        Ok(config)
+    }
+}
+
+#[derive(Debug)]
+pub struct BackendRecord {
+    pub id: Uuid,
+    pub name: Box<str>,
+    pub enabled: bool,
+    pub config: Config,
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -3,6 +3,11 @@
 #![allow(clippy::missing_errors_doc)]
 #![allow(clippy::doc_markdown)]
 
+/// flutter_rust_bridge:ignore
+#[cfg(feature = "backend")]
+pub mod backend;
+
 pub mod constant;
 pub mod event;
+pub mod state;
 pub mod task;

--- a/crates/core/src/state.rs
+++ b/crates/core/src/state.rs
@@ -1,0 +1,29 @@
+use std::path::PathBuf;
+
+use uuid::Uuid;
+
+#[derive(Debug, Clone)]
+pub struct KnownPaths {
+    pub support: PathBuf,
+    pub cache: PathBuf,
+    pub download: PathBuf,
+
+    pub logs: PathBuf,
+    pub ssh_keys: PathBuf,
+}
+
+impl KnownPaths {
+    #[must_use]
+    pub fn repository_path(&self, id: Uuid) -> PathBuf {
+        self.support.join("repository").join(id.to_string())
+    }
+    #[must_use]
+    pub fn backend_path(&self, repository_id: Uuid) -> PathBuf {
+        self.repository_path(repository_id).join("backend")
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct State {
+    pub known_paths: KnownPaths,
+}

--- a/crates/database/Cargo.toml
+++ b/crates/database/Cargo.toml
@@ -12,7 +12,9 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-stride_core.workspace = true
+stride_core = { workspace = true, features = ["backend"] }
+
+serde_json.workspace = true
 
 rusqlite.workspace = true
 uuid.workspace = true

--- a/crates/database/src/migrations/v001_task.rs
+++ b/crates/database/src/migrations/v001_task.rs
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS task_table (
     `annotations` BLOB,
     `udas` BLOB,
     -- Where does this task originate from, null implies stride.
-    `backend` INTEGER,
+    `backend` BLOB,
 
     FOREIGN KEY (project) REFERENCES project_table (id) ON DELETE SET NULL,
     FOREIGN KEY (backend) REFERENCES backend_table (id) ON DELETE SET NULL
@@ -32,8 +32,10 @@ CREATE TABLE IF NOT EXISTS task_dependency_table (
 ) STRICT;
 
 CREATE TABLE IF NOT EXISTS backend_table (
-    id TEXT PRIMARY KEY,
+    id BLOB PRIMARY KEY,
     `name` TEXT NOT NULL CHECK (length(`name`) != 0),
+    enabled INTEGER NOT NULL CHECK (`enabled` = 0 OR `enabled` = 1),
+
     -- Custom properties that the backend stores.
     property TEXT
 ) STRICT;


### PR DESCRIPTION
Related to #103 

This PR implements the mechanism for easily addable/configurable backends.

This is a achieved by making every backend provide a schema of properties and their types (and/or default values) that is required for instantiating a backend. This allows making stride backend agnostic, allowing for addition of multiple backend in the future.

This functionality is currently only implemented on the CLI.